### PR TITLE
Added DocC catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,15 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+var dependencies: [Package.Dependency] = []
+
+if ProcessInfo.processInfo.environment["DEPENDENCY_DOCC"] == "1" {
+    dependencies.append(
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3")
+    )
+}
 
 let package = Package(
     name: "swiftui-flow-navigation",
@@ -17,6 +26,7 @@ let package = Package(
             targets: ["FlowNavigation"]
         ),
     ],
+    dependencies: dependencies,
     targets: [
         .target(
             name: "FlowNavigation"

--- a/Snippets/README.md
+++ b/Snippets/README.md
@@ -1,0 +1,2 @@
+Compile snippets: `swift build`
+Preview snippets: `DEPENDENCY_DOCC=1 swift package --disable-sandbox preview-documentation --target FlowNavigation --include-extended-types` 

--- a/Snippets/hiding-the-back-button.swift
+++ b/Snippets/hiding-the-back-button.swift
@@ -1,0 +1,19 @@
+import FlowNavigation
+import SwiftUI
+
+struct CompletionScreen: FlowScreen {
+    static let screenId = "Completion"
+    
+    func body(control: FlowScreenControl<Void>) -> some View {
+        VStack {
+            Text("Success! You submitted your request!")
+            
+            Button("Okay") {
+                Task {
+                    await control.next()
+                }
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+    }
+}

--- a/Sources/FlowNavigation/Documentation.docc/Articles/hiding-the-back-button.md
+++ b/Sources/FlowNavigation/Documentation.docc/Articles/hiding-the-back-button.md
@@ -1,0 +1,8 @@
+#  Hiding the Back Button
+
+Hiding the Back Button on a Per-Screen Basis
+
+If you need to hide the back button on a `FlowScreen`, such as a completion screen, you can use SwiftUI’s native [`navigationBarBackButtonHidden(_:)`](https://developer.apple.com/documentation/swiftui/view/navigationbarbackbuttonhidden(_:)) modifier.
+Since Flow Navigation is built on `NavigationStack`, this works seamlessly.
+
+@Snippet(path: "swiftui-flow-navigation/Snippets/hiding-the-back-button")

--- a/Sources/FlowNavigation/Documentation.docc/FlowNavigation.md
+++ b/Sources/FlowNavigation/Documentation.docc/FlowNavigation.md
@@ -1,0 +1,7 @@
+# ``FlowNavigation``
+
+Flow Navigation is a **declarative navigation system** for SwiftUI that enables **linear, structured, type-safe flows**.
+
+## Articles
+
+<doc:hiding-the-back-button>


### PR DESCRIPTION
Adds a DocC catalog with a article about hiding the back button.
It uses SPM snippets, which are compiled to ensure they are correct. 
There are also preview instructions in the snippets readme, using the docc-plugin that will only be added if given an environment variable.